### PR TITLE
Feature/bn-refactor-exchange

### DIFF
--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -348,20 +348,27 @@ export default class Exchange extends Base {
     expirationTimestamp,
     overrides = {},
   ) {
+    const quoteTokenQtyBN = toBigNumber(quoteTokenQty);
+    const baseTokenQtyMinBN = toBigNumber(baseTokenQtyMin);
+    const quoteTokenBalanceBN = toBigNumber(await this.quoteTokenBalance);
+    const quoteTokenAllowanceBN = toBigNumber(await this.quoteTokenAllowance);
+
     if (expirationTimestamp < new Date().getTime() / 1000) {
       throw this.errorHandling.error('TIMESTAMP_EXPIRED');
     }
-    if ((await this.quoteTokenBalance) < quoteTokenQty) {
+    if (quoteTokenBalanceBN.lt(quoteTokenQtyBN)) {
       throw this.errorHandling.error('NOT_ENOUGH_QUOTE_TOKEN_BALANCE');
     }
-    if ((await this.quoteTokenAllowance) < quoteTokenQty) {
+    if (quoteTokenAllowanceBN.lt(quoteTokenQtyBN)) {
       throw this.errorHandling.error('TRANSFER_NOT_APPROVED');
     }
 
     this._contract = this.confirmSigner(this.contract);
+    const quoteTokenQtyEBN = toEthersBigNumber(quoteTokenQtyBN);
+    const baseTokenQtyMinEBN = toEthersBigNumber(baseTokenQtyMinBN);
     const txStatus = await this.contract.swapQuoteTokenForBaseToken(
-      quoteTokenQty,
-      baseTokenQtyMin,
+      quoteTokenQtyEBN,
+      baseTokenQtyMinEBN,
       expirationTimestamp,
       this.sanitizeOverrides(overrides),
     );

--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -315,20 +315,27 @@ export default class Exchange extends Base {
     expirationTimestamp,
     overrides = {},
   ) {
+    const baseTokenQtyBN = toBigNumber(baseTokenQty);
+    const quoteTokenQtyMinBN = toBigNumber(quoteTokenQtyMin);
+    const baseTokenBalanceBN = toBigNumber(await this.baseTokenBalance);
+    const baseTokenAllowanceBN = toBigNumber(await this.baseTokenAllowance);
+
     if (expirationTimestamp < new Date().getTime() / 1000) {
       throw this.errorHandling.error('TIMESTAMP_EXPIRED');
     }
-    if ((await this.baseTokenBalance) < baseTokenQty) {
+    if (baseTokenBalanceBN.lt(baseTokenQtyBN)) {
       throw this.errorHandling.error('NOT_ENOUGH_BASE_TOKEN_BALANCE');
     }
-    if ((await this.baseTokenAllowance) < baseTokenQty) {
+    if (baseTokenAllowanceBN.lt(baseTokenQtyBN)) {
       throw this.errorHandling.error('TRANSFER_NOT_APPROVED');
     }
 
     this._contract = this.confirmSigner(this.contract);
+    const baseTokenQtyEBN = toEthersBigNumber(baseTokenQtyBN);
+    const quoteTokenQtyMinEBN = toEthersBigNumber(quoteTokenQtyMinBN);
     const txStatus = await this.contract.swapBaseTokenForQuoteToken(
-      baseTokenQty,
-      quoteTokenQtyMin,
+      baseTokenQtyEBN,
+      quoteTokenQtyMinEBN,
       expirationTimestamp,
       this.sanitizeOverrides(overrides),
     );


### PR DESCRIPTION
Refactors the functions: `swapQuoteTokenForBaseToken` and `swapBaseTokenForQuoteToken` in Exchange.mjs to use `toBigNumber()` and `toEthersBigNumber()`

Note:
Linting - passes
Tests - all green