### PR TITLE
Feature/input-amount from-output-amount

### DIFF
--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -5,6 +5,7 @@ import ErrorHandling from '../ErrorHandling.mjs';
 import {
   calculateBaseTokenQty,
   calculateExchangeRate,
+  calculateInputAmountFromOutputAmount,
   calculateFees,
   calculateLPTokenAmount,
   calculatePriceImpact,
@@ -179,6 +180,38 @@ export default class Exchange extends Base {
     const liquidityFeeInBasisPoints = await this.liquidityFee;
 
     return calculateFees(swapAmount, liquidityFeeInBasisPoints);
+  }
+
+  async calculateInputAmountFromOutputAmount(
+    outputAmount,
+    outputTokenAddress,
+    slippagePercent,
+  ) {
+    const outputTokenAddressLowerCase = outputTokenAddress.toLowerCase();
+    const outputTokenAmountBN = toBigNumber(outputAmount);
+    const slippagePercentBN = toBigNumber(slippagePercent);
+    const liquidityFeeInBasisPointsBN = toBigNumber(await this.liquidityFee);
+
+    let inputTokenReserveQty;
+    let outputTokenReserveQty;
+
+    const internalBalances = await this.contract.internalBalances();
+
+    if (outputTokenAddressLowerCase === this.baseTokenAddress.toLowerCase()) {
+      inputTokenReserveQty = internalBalances.quoteTokenReserveQty;
+      outputTokenReserveQty = internalBalances.baseTokenReserveQty;
+    } else {
+      inputTokenReserveQty = internalBalances.baseTokenReserveQty;
+      outputTokenReserveQty = internalBalances.quoteTokenReserveQty;
+    }
+
+    return calculateInputAmountFromOutputAmount(
+      outputTokenAmountBN,
+      inputTokenReserveQty,
+      outputTokenReserveQty,
+      slippagePercentBN,
+      liquidityFeeInBasisPointsBN,
+    );
   }
 
   async calculateLPTokenAmount(quoteTokenAmount, baseTokenAmount, slippage) {

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -679,8 +679,8 @@ export const calculateFees = (feesInBasisPoints, swapAmount) => {
  */
 export const calculateInputAmountFromOutputAmount = (
   outputTokenAmount,
-  inputTokenReserveQty, // a
-  outputTokenReserveQty, // b
+  inputTokenReserveQty, 
+  outputTokenReserveQty,
   slippagePercent,
   liquidityFeeInBasisPoints,
 ) => {

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -679,7 +679,7 @@ export const calculateFees = (feesInBasisPoints, swapAmount) => {
  */
 export const calculateInputAmountFromOutputAmount = (
   outputTokenAmount,
-  inputTokenReserveQty, 
+  inputTokenReserveQty,
   outputTokenReserveQty,
   slippagePercent,
   liquidityFeeInBasisPoints,

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -660,6 +660,23 @@ export const calculateFees = (feesInBasisPoints, swapAmount) => {
   return fees;
 };
 
+/**
+ * @dev calculates the inputAmount given an OutputAmount
+ *
+ *
+ * inputAmount =  - (outputAmount * inputTokenReserveQty * BASIS_POINTS)
+ *                -----------------------------------------------------------------
+ *                ( outputAmount - outputTokenReserveQty + (outputTokenReserveQty* (slippage/100)) )
+ *                  * (BP - liquidityFeeInBasisPoints )
+ *
+ *
+ * @param  outputTokenAmount - The amount user wants to receive after fees and slippage
+ * @param inputTokenReserveQty - The reserve quantity of the inputToken
+ * @param {*} outputTokenReserveQty - The reserve quantity of the output
+ * @param  slippagePercent - The percentage of the slippage
+ * @param liquidityFeeInBasisPoints - The liquidity fee in BasisPoints
+ * @returns inputAmountFromOutputAmount
+ */
 export const calculateInputAmountFromOutputAmount = (
   outputTokenAmount,
   inputTokenReserveQty, // a
@@ -668,9 +685,6 @@ export const calculateInputAmountFromOutputAmount = (
   liquidityFeeInBasisPoints,
 ) => {
   // cleanse input to BN
-  // here it is assumed that outputTokenAmount is what the
-  // user wants accounting for fees and slippage
-  // i.e outputTokenAmount is actually outputTokenAmountLessFeesLessSlippage
   const outputTokenAmountBN = toBigNumber(outputTokenAmount);
   const inputTokenReserveQtyBN = toBigNumber(inputTokenReserveQty);
   const outputTokenReserveQtyBN = toBigNumber(outputTokenReserveQty);

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -672,7 +672,7 @@ export const calculateFees = (feesInBasisPoints, swapAmount) => {
  *
  * @param  outputTokenAmount - The amount user wants to receive after fees and slippage
  * @param inputTokenReserveQty - The reserve quantity of the inputToken
- * @param {*} outputTokenReserveQty - The reserve quantity of the output
+ * @param outputTokenReserveQty - The reserve quantity of the output
  * @param  slippagePercent - The percentage of the slippage
  * @param liquidityFeeInBasisPoints - The liquidity fee in BasisPoints
  * @returns inputAmountFromOutputAmount

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -2181,5 +2181,138 @@ describe('Exchange', () => {
         calculatedInputAmount.toNumber(),
       );
     });
+
+    it('should calculate the input amount from output amount correctly, accounting for fees and slippage', async () => {
+      // create expiration 50 minutes from now.
+      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
+      const liquidityProvider = accounts[1];
+      const trader = accounts[2];
+      const liquidityProviderInitialBalances = 1000000;
+      const amountToAdd = 1000000;
+      const baseTokenQtyToAdd = 10000;
+      const quoteTokenQtyToAdd = 50000;
+
+      await sdk.changeSigner(liquidityProvider);
+      exchangeClass = new elasticSwapSDK.Exchange(
+        sdk,
+        exchange.address,
+        baseToken.address,
+        quoteToken.address,
+      );
+
+      // send users (liquidity provider) base and quote tokens for easy accounting.
+      await baseToken.transfer(
+        liquidityProvider.address,
+        liquidityProviderInitialBalances,
+      );
+
+      await quoteToken.transfer(
+        liquidityProvider.address,
+        liquidityProviderInitialBalances,
+      );
+
+      // add approvals
+      await exchangeClass.quoteToken.approve(
+        exchangeClass.address,
+        liquidityProviderInitialBalances,
+      );
+
+      await exchangeClass.baseToken.approve(
+        exchangeClass.address,
+        liquidityProviderInitialBalances,
+      );
+
+      await exchangeClass.addLiquidity(
+        baseTokenQtyToAdd,
+        quoteTokenQtyToAdd,
+        1,
+        1,
+        liquidityProvider.address,
+        expiration,
+      );
+
+      await sdk.changeSigner(trader);
+      exchangeClass = new elasticSwapSDK.Exchange(
+        sdk,
+        exchange.address,
+        baseToken.address,
+        quoteToken.address,
+      );
+
+      // send trader quote tokens - 1000000
+      await quoteToken.transfer(trader.address, amountToAdd);
+
+      // add approvals for exchange to trade their quote tokens
+      await exchangeClass.quoteToken.approve(
+        exchangeClass.address,
+        amountToAdd,
+      );
+      // confirm no balance before trade.
+      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(
+        0,
+      );
+      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(
+        amountToAdd,
+      );
+
+      const outputAmount = 10000;
+      const outputAmountBN = toBigNumber(outputAmount);
+
+      const liquidityFeeInBasisPointsBN = toBigNumber(
+        liquidityFeeInBasisPoints,
+      );
+
+      const quoteTokenReserveBalance = await quoteToken.balanceOf(
+        exchangeClass.address,
+      );
+      const quoteTokenReserveBalanceBN = toBigNumber(quoteTokenReserveBalance);
+
+      const pricingConstantK = (
+        await exchangeClass.baseToken.balanceOf(exchangeClass.address)
+      ).multipliedBy(
+        await exchangeClass.quoteToken.balanceOf(exchangeClass.address),
+      );
+      const pricingConstantKBN = toBigNumber(pricingConstantK);
+
+      const baseTokenQtyReserveBN = pricingConstantKBN.dividedBy(
+        quoteTokenReserveBalanceBN,
+      );
+
+      const slippagePercentBN = toBigNumber(5);
+      const BASIS_POINTS = toBigNumber(10000);
+
+      const numerator = outputAmountBN
+        .multipliedBy(quoteTokenReserveBalanceBN)
+        .multipliedBy(BASIS_POINTS)
+        .dp(18, ROUND_DOWN);
+
+      const basisPointDifference = BASIS_POINTS.minus(
+        liquidityFeeInBasisPointsBN,
+      );
+
+      const outputSlippageMultiplier = baseTokenQtyReserveBN
+        .multipliedBy(slippagePercentBN.dividedBy(BigNumber(100)))
+        .dp(18, ROUND_DOWN);
+
+      const outputSlippageTerm = outputAmountBN
+        .plus(outputSlippageMultiplier)
+        .minus(baseTokenQtyReserveBN)
+        .dp(18, ROUND_DOWN);
+
+      const denominator = outputSlippageTerm.multipliedBy(basisPointDifference);
+
+      const calculatedInputAmount = numerator.dividedBy(denominator).abs();
+
+      const expectedInputAmount =
+        await exchangeClass.calculateInputAmountFromOutputAmount(
+          outputAmountBN,
+          baseToken.address,
+          slippagePercentBN,
+        );
+
+      expect(expectedInputAmount.toNumber()).to.equal(
+        calculatedInputAmount.toNumber(),
+      );
+    });
   });
 });


### PR DESCRIPTION
Refers #25 
Tldr: Adds functionality (and tests) to calculate output amount from input amount. This functionality is added to the mathLib and then another function with the same name is added to exchange for the front end to use.

The formula used is:
```
 * inputAmount =  - (outputAmount * inputTokenReserveQty * BASIS_POINTS)
 *                -----------------------------------------------------------------
 *                ( outputAmount - outputTokenReserveQty + (outputTokenReserveQty* (slippage/100)) )
 *                  * (BP - liquidityFeeInBasisPoints )
```

Note:
- Passes linting
- All green tests