### PR TITLE
failing test to prove error in decimal shift

### DIFF
--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -695,7 +695,10 @@ export const calculateQtyToReturnAfterFees = (
     .dp(18, ROUND_DOWN)
     .plus(tokenASwapQtyLessFee);
 
+  const altQtyToReturn =   numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
   const qtyToReturn = numerator.dividedBy(denominator).dp(0, ROUND_DOWN);
+
+  console.log(altQtyToReturn.toString(), qtyToReturn.toString());
 
   return qtyToReturn;
 };

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -697,8 +697,6 @@ export const calculateQtyToReturnAfterFees = (
 
   const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
 
-  console.log("sdk:", qtyToReturn.toString());
-
   return qtyToReturn;
 };
 

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -695,10 +695,9 @@ export const calculateQtyToReturnAfterFees = (
     .dp(18, ROUND_DOWN)
     .plus(tokenASwapQtyLessFee);
 
-  const altQtyToReturn =   numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-  const qtyToReturn = numerator.dividedBy(denominator).dp(0, ROUND_DOWN);
+  const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
 
-  console.log(altQtyToReturn.toString(), qtyToReturn.toString());
+  console.log("sdk:", qtyToReturn.toString());
 
   return qtyToReturn;
 };

--- a/test/utils/mathLib.test.mjs
+++ b/test/utils/mathLib.test.mjs
@@ -45,8 +45,9 @@ describe('MathLib', async () => {
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
 
-      const numerator =
-        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+      const numerator = tokenASwapQtyLessFee
+        .multipliedBy(tokenBReserveQtyBeforeTrade)
+        .dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -68,15 +69,16 @@ describe('MathLib', async () => {
 
     it('Should return the correct value when fees are zero', async () => {
       const tokenSwapQty = BigNumber(1);
-      const tokenAReserveQtyBeforeTrade = BigNumber(970.420420420420420420420);
+      const tokenAReserveQtyBeforeTrade = BigNumber(970.42042042042042042042);
       const tokenBReserveQtyBeforeTrade = BigNumber(3175.696969696969696969696);
       const feeInBasisPoints = BigNumber(0);
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
 
-      const numerator =
-        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+      const numerator = tokenASwapQtyLessFee
+        .multipliedBy(tokenBReserveQtyBeforeTrade)
+        .dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -88,7 +90,7 @@ describe('MathLib', async () => {
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
-        970.420420420420420420,
+        970.42042042042042042,
         3175.696969696969696969,
         0,
       );
@@ -267,8 +269,9 @@ describe('MathLib', async () => {
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
 
-      const numerator =
-        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+      const numerator = tokenASwapQtyLessFee
+        .multipliedBy(tokenBReserveQtyBeforeTrade)
+        .dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -313,8 +316,9 @@ describe('MathLib', async () => {
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
 
-      const numerator =
-        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+      const numerator = tokenASwapQtyLessFee
+        .multipliedBy(tokenBReserveQtyBeforeTrade)
+        .dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -337,30 +341,25 @@ describe('MathLib', async () => {
       const tokenBQtyExpectedLessSlippage = qtyToReturn.multipliedBy(slippageMultiplier);
 
       // Here passing in normal decimals, sdk will convert to BN for calcs
-      expect(
-        calculateOutputAmountLessFees(
-          1,
-          317000,
-          3175.79385113,
-          0,
-          50,
-        ).toString(),
-      ).to.equal(tokenBQtyExpectedLessSlippage.toString());
+      expect(calculateOutputAmountLessFees(1, 317000, 3175.79385113, 0, 50).toString()).to.equal(
+        tokenBQtyExpectedLessSlippage.toString(),
+      );
     });
 
     it('Should calculateOutputAmount correctly, accounting for 0 fees and 0 slippage', async () => {
       // no slippage no fees
       const slippage = ZERO;
       const tokenSwapQty = BigNumber(1);
-      const tokenAReserveQtyBeforeTrade = BigNumber(970.420420420420420420420);
+      const tokenAReserveQtyBeforeTrade = BigNumber(970.42042042042042042042);
       const tokenBReserveQtyBeforeTrade = BigNumber(3175.696969696969696969696);
       const feeInBasisPoints = ZERO;
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
 
-      const numerator =
-        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+      const numerator = tokenASwapQtyLessFee
+        .multipliedBy(tokenBReserveQtyBeforeTrade)
+        .dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -372,7 +371,7 @@ describe('MathLib', async () => {
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
-        970.420420420420420420420,
+        970.42042042042042042042,
         3175.696969696969696969696,
         0,
       );
@@ -387,7 +386,7 @@ describe('MathLib', async () => {
       expect(
         calculateOutputAmountLessFees(
           1,
-          970.420420420420420420420,
+          970.42042042042042042042,
           3175.696969696969696969696,
           0,
           0,

--- a/test/utils/mathLib.test.mjs
+++ b/test/utils/mathLib.test.mjs
@@ -36,9 +36,7 @@ describe('MathLib', async () => {
   });
 
   describe('calculateQtyToReturnAfterFees', () => {
-
-    it.only('Should return the correct values', async () => {
-      
+    it('Should return the correct values', async () => {
       const tokenSwapQty = BigNumber(1);
       const tokenAReserveQtyBeforeTrade = BigNumber(3170);
       const tokenBReserveQtyBeforeTrade = BigNumber(3175.79385113);
@@ -46,8 +44,9 @@ describe('MathLib', async () => {
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
-      
-      const numerator = tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+
+      const numerator =
+        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -55,7 +54,7 @@ describe('MathLib', async () => {
 
       // what the sdk should be doing
       const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
@@ -64,22 +63,20 @@ describe('MathLib', async () => {
         50,
       );
 
-      console.log(qtyToReturn.toString(), SdkCalculatedQtyToReturnAfterFees.toString());
-      
       expect(SdkCalculatedQtyToReturnAfterFees.toString()).to.equal(qtyToReturn.toString());
     });
 
-    it.only('Should return the correct value when fees are zero', async () => {
-           
+    it('Should return the correct value when fees are zero', async () => {
       const tokenSwapQty = BigNumber(1);
-      const tokenAReserveQtyBeforeTrade = BigNumber(970.420420420420420420420); // 21 digits after decimal point
-      const tokenBReserveQtyBeforeTrade = BigNumber(3175.696969696969696969696); // 21 digits after decimal point
+      const tokenAReserveQtyBeforeTrade = BigNumber(970.420420420420420420420);
+      const tokenBReserveQtyBeforeTrade = BigNumber(3175.696969696969696969696);
       const feeInBasisPoints = BigNumber(0);
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
-      
-      const numerator = tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+
+      const numerator =
+        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -87,7 +84,7 @@ describe('MathLib', async () => {
 
       // what the sdk should be doing
       const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
@@ -96,10 +93,7 @@ describe('MathLib', async () => {
         0,
       );
 
-      console.log(qtyToReturn.toString(), SdkCalculatedQtyToReturnAfterFees.toString());
-      
       expect(SdkCalculatedQtyToReturnAfterFees.toString()).to.equal(qtyToReturn.toString());
-
     });
   });
 
@@ -261,7 +255,7 @@ describe('MathLib', async () => {
   });
 
   describe('calculateOutputAmountLessFees', () => {
-    it.only('Should calculateOutputAmount correctly, accounting for fees and  slippage', async () => {
+    it('Should calculateOutputAmount correctly, accounting for fees and  slippage', async () => {
       // slippage and fees
       // 5 percent slippage
       const slippage = BigNumber(5);
@@ -272,8 +266,9 @@ describe('MathLib', async () => {
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
-      
-      const numerator = tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+
+      const numerator =
+        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -281,7 +276,7 @@ describe('MathLib', async () => {
 
       // what the sdk should be doing
       const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
@@ -290,14 +285,11 @@ describe('MathLib', async () => {
         50,
       );
 
-      console.log(qtyToReturn.toString(), SdkCalculatedQtyToReturnAfterFees.toString());
-      
       expect(SdkCalculatedQtyToReturnAfterFees.toString()).to.equal(qtyToReturn.toString());
-      
+
       const slippageMultiplier = BigNumber(1).minus(slippage.dividedBy(BigNumber(100)));
       const tokenBQtyExpectedLessSlippage = qtyToReturn.multipliedBy(slippageMultiplier);
-      console.log("after slippage: ", tokenBQtyExpectedLessSlippage.toString());
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       expect(
         calculateOutputAmountLessFees(
@@ -310,7 +302,7 @@ describe('MathLib', async () => {
       ).to.equal(tokenBQtyExpectedLessSlippage.toString());
     });
 
-    it.only('Should calculateOutputAmount correctly, accounting for fees and 0 slippage', async () => {
+    it('Should calculateOutputAmount correctly, accounting for fees and 0 slippage', async () => {
       // no slippage
       const slippage = ZERO;
       const tokenSwapQty = BigNumber(1);
@@ -320,8 +312,9 @@ describe('MathLib', async () => {
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
-      
-      const numerator = tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+
+      const numerator =
+        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -329,7 +322,7 @@ describe('MathLib', async () => {
 
       // what the sdk should be doing
       const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
@@ -338,14 +331,11 @@ describe('MathLib', async () => {
         50,
       );
 
-      console.log(qtyToReturn.toString(), SdkCalculatedQtyToReturnAfterFees.toString());
-      
       expect(SdkCalculatedQtyToReturnAfterFees.toString()).to.equal(qtyToReturn.toString());
-      
+
       const slippageMultiplier = BigNumber(1).minus(slippage.dividedBy(BigNumber(100)));
       const tokenBQtyExpectedLessSlippage = qtyToReturn.multipliedBy(slippageMultiplier);
-      console.log("after slippage: ", tokenBQtyExpectedLessSlippage.toString());
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       expect(
         calculateOutputAmountLessFees(
@@ -356,11 +346,9 @@ describe('MathLib', async () => {
           50,
         ).toString(),
       ).to.equal(tokenBQtyExpectedLessSlippage.toString());
-
-
     });
 
-    it.only('Should calculateOutputAmount correctly, accounting for 0 fees and 0 slippage', async () => {
+    it('Should calculateOutputAmount correctly, accounting for 0 fees and 0 slippage', async () => {
       // no slippage no fees
       const slippage = ZERO;
       const tokenSwapQty = BigNumber(1);
@@ -370,8 +358,9 @@ describe('MathLib', async () => {
 
       const differenceInBP = BASIS_POINTS.minus(feeInBasisPoints);
       const tokenASwapQtyLessFee = tokenSwapQty.multipliedBy(differenceInBP).dp(18, ROUND_DOWN);
-      
-      const numerator = tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
+
+      const numerator =
+        tokenASwapQtyLessFee.multipliedBy(tokenBReserveQtyBeforeTrade).dp(18, ROUND_DOWN);
       const denominator = tokenAReserveQtyBeforeTrade
         .multipliedBy(BASIS_POINTS)
         .dp(18, ROUND_DOWN)
@@ -379,7 +368,7 @@ describe('MathLib', async () => {
 
       // what the sdk should be doing
       const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
-      
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       const SdkCalculatedQtyToReturnAfterFees = calculateQtyToReturnAfterFees(
         1,
@@ -388,14 +377,12 @@ describe('MathLib', async () => {
         0,
       );
 
-      console.log(qtyToReturn.toString(), SdkCalculatedQtyToReturnAfterFees.toString());
-      
       expect(SdkCalculatedQtyToReturnAfterFees.toString()).to.equal(qtyToReturn.toString());
-      
+
       const slippageMultiplier = BigNumber(1).minus(slippage.dividedBy(BigNumber(100)));
       const tokenBQtyExpectedLessSlippage = qtyToReturn.multipliedBy(slippageMultiplier);
-      console.log("after slippage: ", tokenBQtyExpectedLessSlippage.toString());
-      
+      console.log('after slippage: ', tokenBQtyExpectedLessSlippage.toString());
+
       // Here passing in normal decimals, sdk will convert to BN for calcs
       expect(
         calculateOutputAmountLessFees(
@@ -406,8 +393,6 @@ describe('MathLib', async () => {
           0,
         ).toString(),
       ).to.equal(tokenBQtyExpectedLessSlippage.toString());
-
-
     });
 
     it('Should return an error when incorrect values are provided', async () => {


### PR DESCRIPTION
Failing test to prove there is at least 1 incorrect decimal shift happening in the mathLib.

(There are 2 places this incorrect shift is happening, one in the `calculateToReturnAfterFees`, and other `calculateLiquidityTokenQtyForSingleAssetEntry`, the latter has to anyway be re-written due to the change in the calcualtion due to the initial audit findings)

Update:
* qtyToReturn in `calculateQtyToReturnAfterFees` is now rounds down using 18 decimals of precision 
```
const qtyToReturn = numerator.dividedBy(denominator).dp(18, ROUND_DOWN);
```
* Tests are green (33 passing)