### PR TITLE
ethers BN math lib refactor

### DIFF
--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -471,13 +471,13 @@ export default class Exchange extends ERC20 {
       this.sdk.multicall.enqueue(this.abi, this.address, 'TOTAL_LIQUIDITY_FEE'),
       this.sdk.multicall.enqueue(this.abi, this.address, 'internalBalances'),
     ]);
-    const rawOutput = getBaseTokenQtyFromQuoteTokenQty(
+    const rawBaseTokenQty = getBaseTokenQtyFromQuoteTokenQty(
       this.toEthersBigNumber(quoteTokenQty, this.quoteToken.decimals),
       baseTokenReserveQty,
       fee,
       internalBalances,
     );
-    return this.toBigNumber(rawOutput, this.baseToken.decimals);
+    return this.toBigNumber(rawBaseTokenQty, this.baseToken.decimals);
   }
 
   // CALCULATIONS

--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -400,12 +400,12 @@ export default class Exchange extends ERC20 {
 
     // save the user gas by confirming that the allowances and balance match the request
     validate(baseTokenAllowance.gte(baseTokenQty), {
-      message: `Not allowed to spend that much base token ${this.baseToken.symbol}`,
+      message: `Not allowed to spend that much ${this.baseToken.symbol} token`,
       prefix,
     });
 
     validate(this.toBigNumber(baseTokenQty).lt(baseTokenBalance), {
-      message: `You don't have enough base token ${this.baseToken.symbol}`,
+      message: `You don't have enough ${this.baseToken.symbol} token`,
       prefix,
     });
 
@@ -442,12 +442,12 @@ export default class Exchange extends ERC20 {
 
     // save the user gas by confirming that the allowances and balance match the request
     validate(quoteTokenAllowance.gte(quoteTokenQty), {
-      message: `Not allowed to spend that much quote token ${this.quoteToken.symbol}`,
+      message: `Not allowed to spend that much ${this.quoteToken.symbol} token`,
       prefix,
     });
 
     validate(this.toBigNumber(quoteTokenQty).lt(quoteTokenBalance), {
-      message: `You don't have enough quote token ${this.quoteToken.symbol}`,
+      message: `You don't have enough ${this.quoteToken.symbol} token`,
       prefix,
     });
 

--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -415,7 +415,7 @@ export default class Exchange extends ERC20 {
       prefix,
     });
 
-    return this._handleTransaction(
+    const receipt = await this._handleTransaction(
       await this.contract.swapBaseTokenForQuoteToken(
         this.toEthersBigNumber(baseTokenQty, this.baseToken.decimals),
         this.toEthersBigNumber(quoteTokenQtyMin, this.quoteToken.decimals),
@@ -423,6 +423,14 @@ export default class Exchange extends ERC20 {
         this.sanitizeOverrides(overrides),
       ),
     );
+
+    // update balances
+    await Promise.all([
+      this.baseToken.balanceOf(this.sdk.account, { multicall: true }),
+      this.quoteToken.balanceOf(this.sdk.account, { multicall: true }),
+    ]);
+
+    return receipt;
   }
 
   async swapQuoteTokenForBaseToken(
@@ -457,7 +465,7 @@ export default class Exchange extends ERC20 {
       prefix,
     });
 
-    return this._handleTransaction(
+    const receipt = await this._handleTransaction(
       await this.contract.swapQuoteTokenForBaseToken(
         this.toEthersBigNumber(quoteTokenQty, this.quoteToken.decimals),
         this.toEthersBigNumber(baseTokenQtyMin, this.baseToken.decimals),
@@ -465,6 +473,14 @@ export default class Exchange extends ERC20 {
         this.sanitizeOverrides(overrides),
       ),
     );
+
+    // update balances
+    await Promise.all([
+      this.baseToken.balanceOf(this.sdk.account, { multicall: true }),
+      this.quoteToken.balanceOf(this.sdk.account, { multicall: true }),
+    ]);
+
+    return receipt;
   }
 
   // CALCULATIONS

--- a/src/exchange/Exchange.mjs
+++ b/src/exchange/Exchange.mjs
@@ -460,12 +460,11 @@ export default class Exchange extends ERC20 {
   // CALCULATIONS
 
   async calculateBaseTokenQty(quoteTokenQty, baseTokenQtyMin) {
-    const [baseTokenReserveQty, liquidityFeeInBasisPoints, internalBalances] =
-      await Promise.all([
-        this.baseToken.balanceOf(this.address),
-        this.TOTAL_LIQUIDITY_FEE(),
-        this.internalBalances(),
-      ]);
+    const [baseTokenReserveQty, liquidityFeeInBasisPoints, internalBalances] = await Promise.all([
+      this.baseToken.balanceOf(this.address),
+      this.TOTAL_LIQUIDITY_FEE(),
+      this.internalBalances(),
+    ]);
 
     return calculateBaseTokenQty(
       quoteTokenQty,

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -10,7 +10,7 @@ export const WAD = ethers.utils.parseUnits('1', 18);
  * @param {ethers.BigNumber} baseTokenReserveQty current baseToken.balanceOf(exchange)
  * @param {ethers.BigNumber} fee fee amount in basis points
  * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty}
- * @returns 
+ * @returns baseToken qty
  */
 export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, internalBalances) => {
   // check to see if we have experienced quote token Decay / a rebase down event
@@ -48,7 +48,7 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
  * @param {ethers.BigNumber} baseTokenQty 
  * @param {ethers.BigNumber} fee 
  * @param {ethers.BigNumber} internalBalances 
- * @returns 
+ * @returns quoteToken qty
  */
 export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) => {
   return calculateQtyToReturnAfterFees(
@@ -65,7 +65,7 @@ export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) => {
  * @param {ethers.BigNumber} tokenAReserveQty 
  * @param {ethers.BigNumber} tokenBReserveQty 
  * @param {ethers.BigNumber} fee in basis points
- * @returns 
+ * @returns token qty
  */
 export const calculateQtyToReturnAfterFees = (
   tokenASwapQty,
@@ -81,7 +81,15 @@ export const calculateQtyToReturnAfterFees = (
   return qtyToReturn;
 };
 
-export const wDiv = (
+/**
+ * returns a / b in the form of a WAD integer (18 decimals of precision)
+ * NOTE: this rounds to the nearest integer (up or down). For example .666666 would end up
+ * rounding to .66667.
+ * @param {ethers.BigNumber} a 
+ * @param {ethers.BigNumber} b 
+ * @returns wad value of a/b
+ */
+const wDiv = (
   a, b
 ) => {
   return (a.mul(WAD).add(b.div(2))).div(b);

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -16,11 +16,16 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
   // check to see if we have experienced quote token Decay / a rebase down event
   if (baseTokenReserveQty.lt(internalBalances.baseTokenReserveQty)) {
     // we have less reserves than our current price curve will expect, we need to adjust the curve
-    const pricingRatio = internalBalances.baseTokenReserveQty.mul(WAD).div(
+    const pricingRatio = wDiv(
+      internalBalances.baseTokenReserveQty,
       internalBalances.quoteTokenReserveQty,
     );
     //    ^ is Omega
-    const impliedQuoteTokenQty = baseTokenReserveQty.mul(WAD).div(pricingRatio);
+    const impliedQuoteTokenQty = wDiv( 
+      baseTokenReserveQty,
+      pricingRatio
+    );
+
     return calculateQtyToReturnAfterFees(
       quoteTokenQty,
       impliedQuoteTokenQty,
@@ -36,7 +41,6 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
     fee,
   );
 }
-
 
 /**
  * Returns the quote qty expected to output (given no slippage) based on the baseTokenQty
@@ -54,7 +58,6 @@ export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) => {
     fee,
   );
 }
-
 
 /**
  * 
@@ -77,6 +80,12 @@ export const calculateQtyToReturnAfterFees = (
   const qtyToReturn = numerator.div(denominator);
   return qtyToReturn;
 };
+
+export const wDiv = (
+  a, b
+) => {
+  return (a.mul(WAD).add(b.div(2))).div(b);
+}
 
 export default {
   BASIS_POINTS,

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers } from 'ethers';
 
 export const BASIS_POINTS = ethers.BigNumber.from('10000');
 export const WAD = ethers.utils.parseUnits('1', 18);
@@ -9,10 +9,16 @@ export const WAD = ethers.utils.parseUnits('1', 18);
  * @param {ethers.BigNumber} quoteTokenQty quoteTokenQty to swap
  * @param {ethers.BigNumber} baseTokenReserveQty current baseToken.balanceOf(exchange)
  * @param {ethers.BigNumber} fee fee amount in basis points
- * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty}
+ * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty } 
+ * representing internal accounting of the exchange contract
  * @returns baseToken qty
  */
-export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, internalBalances) => {
+export const getBaseQtyFromQuoteQty = (
+  quoteTokenQty,
+  baseTokenReserveQty,
+  fee,
+  internalBalances,
+) => {
   // check to see if we have experienced quote token Decay / a rebase down event
   if (baseTokenReserveQty.lt(internalBalances.baseTokenReserveQty)) {
     // we have less reserves than our current price curve will expect, we need to adjust the curve
@@ -21,10 +27,7 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
       internalBalances.quoteTokenReserveQty,
     );
     //    ^ is Omega
-    const impliedQuoteTokenQty = wDiv( 
-      baseTokenReserveQty,
-      pricingRatio
-    );
+    const impliedQuoteTokenQty = wDiv(baseTokenReserveQty, pricingRatio);
 
     return calculateQtyToReturnAfterFees(
       quoteTokenQty,
@@ -32,7 +35,7 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
       baseTokenReserveQty,
       fee,
     );
-  } 
+  }
   // we have the same or more reserves, no need to alter the curve.
   return calculateQtyToReturnAfterFees(
     quoteTokenQty,
@@ -40,30 +43,29 @@ export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, 
     internalBalances.baseTokenReserveQty,
     fee,
   );
-}
+};
 
 /**
  * Returns the quote qty expected to output (given no slippage) based on the baseTokenQty
  * passed in for the given internal balances and fee.
- * @param {ethers.BigNumber} baseTokenQty 
- * @param {ethers.BigNumber} fee 
- * @param {ethers.BigNumber} internalBalances 
+ * @param {ethers.BigNumber} baseTokenQty
+ * @param {ethers.BigNumber} fee
+ * @param {ethers.BigNumber} internalBalances
  * @returns quoteToken qty
  */
-export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) => {
-  return calculateQtyToReturnAfterFees(
+export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) =>
+  calculateQtyToReturnAfterFees(
     baseTokenQty,
     internalBalances.baseTokenReserveQty,
     internalBalances.quoteTokenReserveQty,
     fee,
   );
-}
 
 /**
- * 
- * @param {ethers.BigNumber} tokenASwapQty 
- * @param {ethers.BigNumber} tokenAReserveQty 
- * @param {ethers.BigNumber} tokenBReserveQty 
+ *
+ * @param {ethers.BigNumber} tokenASwapQty
+ * @param {ethers.BigNumber} tokenAReserveQty
+ * @param {ethers.BigNumber} tokenBReserveQty
  * @param {ethers.BigNumber} fee in basis points
  * @returns token qty
  */
@@ -85,19 +87,15 @@ export const calculateQtyToReturnAfterFees = (
  * returns a / b in the form of a WAD integer (18 decimals of precision)
  * NOTE: this rounds to the nearest integer (up or down). For example .666666 would end up
  * rounding to .66667.
- * @param {ethers.BigNumber} a 
- * @param {ethers.BigNumber} b 
+ * @param {ethers.BigNumber} a
+ * @param {ethers.BigNumber} b
  * @returns wad value of a/b
  */
-const wDiv = (
-  a, b
-) => {
-  return (a.mul(WAD).add(b.div(2))).div(b);
-}
+const wDiv = (a, b) => a.mul(WAD).add(b.div(2)).div(b);
 
 export default {
   BASIS_POINTS,
   calculateQtyToReturnAfterFees,
   getBaseQtyFromQuoteQty,
-  getQuoteQtyFromBaseQty
-}
+  getQuoteQtyFromBaseQty,
+};

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -9,11 +9,11 @@ export const WAD = ethers.utils.parseUnits('1', 18);
  * @param {ethers.BigNumber} quoteTokenQty quoteTokenQty to swap
  * @param {ethers.BigNumber} baseTokenReserveQty current baseToken.balanceOf(exchange)
  * @param {ethers.BigNumber} fee fee amount in basis points
- * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty } 
+ * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty }
  * representing internal accounting of the exchange contract
  * @returns baseToken qty
  */
-export const getBaseQtyFromQuoteQty = (
+export const getBaseTokenQtyFromQuoteTokenQty = (
   quoteTokenQty,
   baseTokenReserveQty,
   fee,
@@ -50,11 +50,11 @@ export const getBaseQtyFromQuoteQty = (
  * passed in for the given internal balances and fee.
  * @param {ethers.BigNumber} baseTokenQty
  * @param {ethers.BigNumber} fee fee amount in basis points
- * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty } 
+ * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty }
  * representing internal accounting of the exchange contract
  * @returns quoteToken qty
  */
-export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) =>
+export const getQuoteTokenQtyFromBaseTokenQty = (baseTokenQty, fee, internalBalances) =>
   calculateQtyToReturnAfterFees(
     baseTokenQty,
     internalBalances.baseTokenReserveQty,
@@ -97,6 +97,6 @@ const wDiv = (a, b) => a.mul(WAD).add(b.div(2)).div(b);
 export default {
   BASIS_POINTS,
   calculateQtyToReturnAfterFees,
-  getBaseQtyFromQuoteQty,
-  getQuoteQtyFromBaseQty,
+  getBaseTokenQtyFromQuoteTokenQty,
+  getQuoteTokenQtyFromBaseTokenQty,
 };

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -49,8 +49,9 @@ export const getBaseQtyFromQuoteQty = (
  * Returns the quote qty expected to output (given no slippage) based on the baseTokenQty
  * passed in for the given internal balances and fee.
  * @param {ethers.BigNumber} baseTokenQty
- * @param {ethers.BigNumber} fee
- * @param {ethers.BigNumber} internalBalances
+ * @param {ethers.BigNumber} fee fee amount in basis points
+ * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty } 
+ * representing internal accounting of the exchange contract
  * @returns quoteToken qty
  */
 export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) =>
@@ -66,7 +67,7 @@ export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) =>
  * @param {ethers.BigNumber} tokenASwapQty
  * @param {ethers.BigNumber} tokenAReserveQty
  * @param {ethers.BigNumber} tokenBReserveQty
- * @param {ethers.BigNumber} fee in basis points
+ * @param {ethers.BigNumber} fee fee amount in basis points
  * @returns token qty
  */
 export const calculateQtyToReturnAfterFees = (

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -1,0 +1,85 @@
+import { ethers } from "ethers";
+
+export const BASIS_POINTS = ethers.BigNumber.from('10000');
+export const WAD = ethers.utils.parseUnits('1', 18);
+
+/**
+ * 
+ * @param {ethers.BigNumber} quoteTokenQty 
+ * @param {ethers.BigNumber} baseTokenReserveQty 
+ * @param {ethers.BigNumber} fee 
+ * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty}
+ * @returns 
+ */
+export const getBaseQtyFromQuoteQty = (quoteTokenQty, baseTokenReserveQty, fee, internalBalances) => {
+  // check to see if we have experienced quote token Decay / a rebase down event
+  if (baseTokenReserveQty.lt(internalBalances.baseTokenReserveQty)) {
+    // we have less reserves than our current price curve will expect, we need to adjust the curve
+    const pricingRatio = internalBalances.baseTokenReserveQty.mul(WAD).div(
+      internalBalances.quoteTokenReserveQty,
+    );
+    //    ^ is Omega
+    const impliedQuoteTokenQty = baseTokenReserveQty.mul(WAD).div(pricingRatio);
+    return calculateQtyToReturnAfterFees(
+      quoteTokenQty,
+      impliedQuoteTokenQty,
+      baseTokenReserveQty,
+      fee,
+    );
+  } 
+  // we have the same or more reserves, no need to alter the curve.
+  return calculateQtyToReturnAfterFees(
+    quoteTokenQty,
+    internalBalances.quoteTokenReserveQty,
+    internalBalances.baseTokenReserveQty,
+    fee,
+  );
+}
+
+
+/**
+ * Returns the quote qty expected to output (given no slippage) based on the baseTokenQty
+ * passed in for the given internal balances and fee.
+ * @param {ethers.BigNumber} baseTokenQty 
+ * @param {ethers.BigNumber} fee 
+ * @param {ethers.BigNumber} internalBalances 
+ * @returns 
+ */
+export const getQuoteQtyFromBaseQty = (baseTokenQty, fee, internalBalances) => {
+  return calculateQtyToReturnAfterFees(
+    baseTokenQty,
+    internalBalances.baseTokenReserveQty,
+    internalBalances.quoteTokenReserveQty,
+    fee,
+  );
+}
+
+
+/**
+ * 
+ * @param {ethers.BigNumber} tokenASwapQty 
+ * @param {ethers.BigNumber} tokenAReserveQty 
+ * @param {ethers.BigNumber} tokenBReserveQty 
+ * @param {ethers.BigNumber} fee in basis points
+ * @returns 
+ */
+export const calculateQtyToReturnAfterFees = (
+  tokenASwapQty,
+  tokenAReserveQty,
+  tokenBReserveQty,
+  fee,
+) => {
+  const differenceInBP = BASIS_POINTS.sub(fee);
+  const tokenASwapQtyLessFee = tokenASwapQty.mul(differenceInBP);
+  const numerator = tokenASwapQtyLessFee.mul(tokenBReserveQty);
+  const denominator = tokenAReserveQty.mul(BASIS_POINTS).add(tokenASwapQtyLessFee);
+  const qtyToReturn = numerator.div(denominator);
+  return qtyToReturn;
+};
+
+export default {
+  BASIS_POINTS,
+  calculateQtyToReturnAfterFees,
+  getBaseQtyFromQuoteQty,
+  getQuoteQtyFromBaseQty
+}

--- a/src/utils/mathLib2.mjs
+++ b/src/utils/mathLib2.mjs
@@ -4,10 +4,11 @@ export const BASIS_POINTS = ethers.BigNumber.from('10000');
 export const WAD = ethers.utils.parseUnits('1', 18);
 
 /**
- * 
- * @param {ethers.BigNumber} quoteTokenQty 
- * @param {ethers.BigNumber} baseTokenReserveQty 
- * @param {ethers.BigNumber} fee 
+ * get the base qty expected to output (assuming no slippage) based on the quoteTokenQty
+ * passed in.
+ * @param {ethers.BigNumber} quoteTokenQty quoteTokenQty to swap
+ * @param {ethers.BigNumber} baseTokenReserveQty current baseToken.balanceOf(exchange)
+ * @param {ethers.BigNumber} fee fee amount in basis points
  * @param {object} internalBalances { baseTokenReserveQty, quoteTokenReserveQty}
  * @returns 
  */

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -818,8 +818,12 @@ describe('Exchange', () => {
       );
 
       // confirm the exchange has 0 balance for base and quote token
-      expect((await baseToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
+      expect(
+        (await baseToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
+      expect(
+        (await quoteToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
     });
 
     it('Should baseToken balance be less than baseToken to be swapped', async () => {
@@ -865,8 +869,12 @@ describe('Exchange', () => {
       await expectThrowsAsync(testMethod, "Exchange: You don't have enough ETM");
 
       // confirm the exchange has 0 balance for base and quote token
-      expect((await baseToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
+      expect(
+        (await baseToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
+      expect(
+        (await quoteToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
     });
 
     it('Should quoteToken balance be less than quoteToken to be swapped', async () => {
@@ -912,8 +920,12 @@ describe('Exchange', () => {
       await expectThrowsAsync(testMethod, "Exchange: You don't have enough FUSD");
 
       // confirm the exchange has 0 balance for base and quote token
-      expect((await baseToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
+      expect(
+        (await baseToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
+      expect(
+        (await quoteToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
     });
 
     it('Should timestamp be expired', async () => {
@@ -958,8 +970,12 @@ describe('Exchange', () => {
       await expectThrowsAsync(testMethod, 'Exchange: Requested expiration is in the past');
 
       // confirm the exchange has 0 balance for base and quote token
-      expect((await baseToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(exchange.address)).toNumber()).to.equal(0);
+      expect(
+        (await baseToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
+      expect(
+        (await quoteToken.balanceOf(exchange.address, { multicall: true })).toNumber(),
+      ).to.equal(0);
     });
 
     it('Should ADD quote and base token liquidity', async () => {

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -692,8 +692,12 @@ describe('Exchange', () => {
       await sdk.changeSigner(trader);
       await exchangeInstance.quoteToken.approve(exchangeInstance.address, amountToAdd);
       // confirm no balance before trade.
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+      expect((await baseToken.balanceOf(trader.address, { multicall: true })).toNumber()).to.equal(
+        0,
+      );
+      expect((await quoteToken.balanceOf(trader.address, { multicall: true })).toNumber()).to.equal(
+        amountToAdd,
+      );
 
       // trader executes the first trade, our pricing should be ~1:1 currently minus fees
       const swapAmount = 100000;

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -234,7 +234,7 @@ describe('Exchange', () => {
         expiration,
       );
 
-      await expectThrowsAsync(testMethod, 'You don\'t have enough ETM token');
+      await expectThrowsAsync(testMethod, "Exchange: You don't have enough ETM token");
     });
 
     it('Fails when user approval is not sufficient', async () => {
@@ -277,13 +277,6 @@ describe('Exchange', () => {
         expiration,
       );
 
-      const exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
-
       // send trader base tokens
       const trader = accounts[4];
       const amountToAdd = 50000;
@@ -292,14 +285,14 @@ describe('Exchange', () => {
       // add approvals for exchange to trade their quote tokens
       await sdk.changeSigner(trader);
       const swapAmount = 10000000;
-      // await exchangeClass.baseToken.approve(exchangeClass.address, swapAmount);
+
       // confirm no balance before trade.
       expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
       expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
       // swap tokens
-      const testMethod = exchangeClass.swapBaseTokenForQuoteToken.bind(
-        exchangeClass,
+      const testMethod = exchangeInstance.swapBaseTokenForQuoteToken.bind(
+        exchangeInstance,
         swapAmount,
         1,
         expiration,
@@ -350,13 +343,6 @@ describe('Exchange', () => {
         expiration,
       );
 
-      const exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
-
       // send trader base tokens
       const trader = accounts[4];
       const amountToAdd = 50000;
@@ -365,14 +351,14 @@ describe('Exchange', () => {
       // add approvals for exchange to trade their quote tokens
       await sdk.changeSigner(trader);
       const swapAmount = 500;
-      await exchangeClass.baseToken.approve(exchangeClass.address, swapAmount);
+      await exchangeInstance.baseToken.approve(exchangeInstance.address, swapAmount);
       // confirm no balance before trade.
       expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
       expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
       // swap tokens
-      const testMethod = exchangeClass.swapBaseTokenForQuoteToken.bind(
-        exchangeClass,
+      const testMethod = exchangeInstance.swapBaseTokenForQuoteToken.bind(
+        exchangeInstance,
         swapAmount,
         1,
         expirationInvalid,
@@ -381,18 +367,16 @@ describe('Exchange', () => {
       await expectThrowsAsync(testMethod, 'Exchange: Requested expiration is in the past');
     });
 
-    it.only('Should price trades correctly', async () => {
+    it('Should price trades correctly', async () => {
+      const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
       // create expiration 50 minutes from now.
       const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 10000;
-      const quoteTokenQtyToAdd = 50000;
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const liquidityProvider = accounts[1];
+      const liquidityProviderInitialBalances = 1000000;
+      const baseTokenQtyToAdd = 500000;
+      const quoteTokenQtyToAdd = 100000;
+      const exchangeInstance = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -400,24 +384,22 @@ describe('Exchange', () => {
       );
 
       // send users (liquidity provider) base and quote tokens for easy accounting.
-
       await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
-
       await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+      await sdk.changeSigner(liquidityProvider);
 
       // add approvals
-
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.quoteToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.baseToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.addLiquidity(
+      await exchangeInstance.addLiquidity(
         baseTokenQtyToAdd,
         quoteTokenQtyToAdd,
         1,
@@ -425,364 +407,370 @@ describe('Exchange', () => {
         liquidityProvider.address,
         expiration,
       );
-
+      // send trader quote tokens
+      const trader = accounts[4];
+      const amountToAdd = 500000;
+      await baseToken.transfer(trader.address, amountToAdd);
       await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
+      // add approvals for exchange to trade their quote tokens
+      await exchangeInstance.baseToken.approve(exchangeInstance.address, amountToAdd);
+      // confirm no balance before trade.
+      expect((await quoteToken.balanceOf(trader.address, { multicall: true })).toNumber()).to.equal(
+        0,
+      );
+      expect((await baseToken.balanceOf(trader.address, { multicall: true })).toNumber()).to.equal(
+        amountToAdd,
       );
 
-      // send trader quote tokens
-      await baseToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.baseToken.approve(exchangeClass.address, amountToAdd);
-      // confirm no balance before trade.
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
-
-      // trader executes the first trade, our pricing should be ~1:1 currently minus fees
+      // trader executes the first trade
       const swapAmount = 100000;
+      const liquidityFee = 0.005;
       const expectedFee = swapAmount * liquidityFee;
 
-      const baseTokenReserveBalance = await baseToken.balanceOf(exchangeClass.address);
+      const baseTokenReserveBalance = await baseToken.balanceOf(exchangeInstance.address);
       const pricingConstantK =
-        (await exchangeClass.baseToken.balanceOf(exchangeClass.address)) *
-        (await exchangeClass.quoteToken.balanceOf(exchangeClass.address));
+        (await exchangeInstance.baseToken.balanceOf(exchangeInstance.address)) *
+        (await exchangeInstance.quoteToken.balanceOf(exchangeInstance.address));
       const quoteTokenQtyReserveBeforeTrade = pricingConstantK / baseTokenReserveBalance.toNumber();
       const quoteTokenQtyReserveAfterTrade =
         pricingConstantK / (baseTokenReserveBalance.toNumber() + swapAmount - expectedFee);
       const quoteTokenQtyExpected =
         quoteTokenQtyReserveBeforeTrade - quoteTokenQtyReserveAfterTrade;
 
-      await exchangeClass.swapBaseTokenForQuoteToken(swapAmount, 1, expiration);
-      // confirm trade occurred at expected
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(
-        Math.trunc(quoteTokenQtyExpected),
+      const quoteTokenQtyCalculated = await exchangeInstance.getQuoteTokenQtyFromBaseTokenQty(
+        swapAmount,
       );
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(
-        amountToAdd - swapAmount,
+
+      await exchangeInstance.swapBaseTokenForQuoteToken(swapAmount, 1, expiration);
+
+      expect(Math.floor(quoteTokenQtyCalculated.toNumber())).to.be.equal(
+        Math.floor(quoteTokenQtyExpected),
+      );
+      expect(Math.floor((await quoteToken.balanceOf(trader.address)).toNumber())).to.equal(
+        Math.floor(quoteTokenQtyExpected),
+      );
+      expect(Math.floor((await baseToken.balanceOf(trader.address)).toNumber())).to.equal(
+        Math.floor(amountToAdd - swapAmount),
       );
     });
   });
 
-  // TODO: Reenable this when the functionality is reintroduced
-  describe.skip('swapQuoteTokenForBaseToken', () => {
-    it('Should quoteToken wallet balance be less than quoteToken to be swapped', async () => {
-      // create expiration 50 minutes from now.
-      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 10000;
-      const quoteTokenQtyToAdd = 50000;
+  // // TODO: Reenable this when the functionality is reintroduced
+  // describe.skip('swapQuoteTokenForBaseToken', () => {
+  //   it('Should quoteToken wallet balance be less than quoteToken to be swapped', async () => {
+  //     // create expiration 50 minutes from now.
+  //     const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
+  //     const liquidityProvider = accounts[1];
+  //     const trader = accounts[2];
+  //     const liquidityProviderInitialBalances = 1000000;
+  //     const amountToAdd = 1000000;
+  //     const baseTokenQtyToAdd = 10000;
+  //     const quoteTokenQtyToAdd = 50000;
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(liquidityProvider);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send users (liquidity provider) base and quote tokens for easy accounting.
+  //     // send users (liquidity provider) base and quote tokens for easy accounting.
 
-      await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      // add approvals
+  //     // add approvals
 
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.quoteToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.baseToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.addLiquidity(
-        baseTokenQtyToAdd,
-        quoteTokenQtyToAdd,
-        1,
-        1,
-        liquidityProvider.address,
-        expiration,
-      );
+  //     await exchangeClass.addLiquidity(
+  //       baseTokenQtyToAdd,
+  //       quoteTokenQtyToAdd,
+  //       1,
+  //       1,
+  //       liquidityProvider.address,
+  //       expiration,
+  //     );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(trader);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send trader quote tokens
-      await quoteToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
-      // confirm no balance before trade.
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+  //     // send trader quote tokens
+  //     await quoteToken.transfer(trader.address, amountToAdd);
+  //     // add approvals for exchange to trade their quote tokens
+  //     await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
+  //     // confirm no balance before trade.
+  //     expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
+  //     expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
-      // swap tokens
-      const swapAmount = 10000000;
-      const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
-        exchangeClass,
-        swapAmount,
-        1,
-        expiration,
-      );
+  //     // swap tokens
+  //     const swapAmount = 10000000;
+  //     const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
+  //       exchangeClass,
+  //       swapAmount,
+  //       1,
+  //       expiration,
+  //     );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 12, Message: NOT_ENOUGH_QUOTE_TOKEN_BALANCE, Path: unknown.',
-      );
-    });
+  //     await expectThrowsAsync(
+  //       testMethod,
+  //       'Origin: exchange, Code: 12, Message: NOT_ENOUGH_QUOTE_TOKEN_BALANCE, Path: unknown.',
+  //     );
+  //   });
 
-    it('Should quoteToken allowance balance be less than quoteToken to be swapped', async () => {
-      // create expiration 50 minutes from now.
-      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 10000;
-      const quoteTokenQtyToAdd = 50000;
+  //   it('Should quoteToken allowance balance be less than quoteToken to be swapped', async () => {
+  //     // create expiration 50 minutes from now.
+  //     const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
+  //     const liquidityProvider = accounts[1];
+  //     const trader = accounts[2];
+  //     const liquidityProviderInitialBalances = 1000000;
+  //     const amountToAdd = 1000000;
+  //     const baseTokenQtyToAdd = 10000;
+  //     const quoteTokenQtyToAdd = 50000;
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(liquidityProvider);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send users (liquidity provider) base and quote tokens for easy accounting.
+  //     // send users (liquidity provider) base and quote tokens for easy accounting.
 
-      await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      // add approvals
+  //     // add approvals
 
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.quoteToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.baseToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.addLiquidity(
-        baseTokenQtyToAdd,
-        quoteTokenQtyToAdd,
-        1,
-        1,
-        liquidityProvider.address,
-        expiration,
-      );
+  //     await exchangeClass.addLiquidity(
+  //       baseTokenQtyToAdd,
+  //       quoteTokenQtyToAdd,
+  //       1,
+  //       1,
+  //       liquidityProvider.address,
+  //       expiration,
+  //     );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(trader);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send trader quote tokens
-      await quoteToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.quoteToken.approve(exchangeClass.address, 1);
-      // confirm no balance before trade.
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+  //     // send trader quote tokens
+  //     await quoteToken.transfer(trader.address, amountToAdd);
+  //     // add approvals for exchange to trade their quote tokens
+  //     await exchangeClass.quoteToken.approve(exchangeClass.address, 1);
+  //     // confirm no balance before trade.
+  //     expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
+  //     expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
-      // swap tokens
-      const swapAmount = 100000;
-      const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
-        exchangeClass,
-        swapAmount,
-        1,
-        expiration,
-      );
+  //     // swap tokens
+  //     const swapAmount = 100000;
+  //     const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
+  //       exchangeClass,
+  //       swapAmount,
+  //       1,
+  //       expiration,
+  //     );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 13, Message: TRANSFER_NOT_APPROVED_BY_USER, Path: unknown.',
-      );
-    });
+  //     await expectThrowsAsync(
+  //       testMethod,
+  //       'Origin: exchange, Code: 13, Message: TRANSFER_NOT_APPROVED_BY_USER, Path: unknown.',
+  //     );
+  //   });
 
-    it('Should timestamp be expired', async () => {
-      // create expiration 50 minutes from now.
-      const expirationValid = Math.round(new Date().getTime() / 1000 + 60 * 50);
-      // create expiration 50 minutes before now.
-      const expirationInvalid = Math.round(new Date().getTime() / 1000 - 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 10000;
-      const quoteTokenQtyToAdd = 50000;
+  //   it('Should timestamp be expired', async () => {
+  //     // create expiration 50 minutes from now.
+  //     const expirationValid = Math.round(new Date().getTime() / 1000 + 60 * 50);
+  //     // create expiration 50 minutes before now.
+  //     const expirationInvalid = Math.round(new Date().getTime() / 1000 - 60 * 50);
+  //     const liquidityProvider = accounts[1];
+  //     const trader = accounts[2];
+  //     const liquidityProviderInitialBalances = 1000000;
+  //     const amountToAdd = 1000000;
+  //     const baseTokenQtyToAdd = 10000;
+  //     const quoteTokenQtyToAdd = 50000;
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(liquidityProvider);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send users (liquidity provider) base and quote tokens for easy accounting.
+  //     // send users (liquidity provider) base and quote tokens for easy accounting.
 
-      await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      // add approvals
+  //     // add approvals
 
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.quoteToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.baseToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.addLiquidity(
-        baseTokenQtyToAdd,
-        quoteTokenQtyToAdd,
-        1,
-        1,
-        liquidityProvider.address,
-        expirationValid,
-      );
+  //     await exchangeClass.addLiquidity(
+  //       baseTokenQtyToAdd,
+  //       quoteTokenQtyToAdd,
+  //       1,
+  //       1,
+  //       liquidityProvider.address,
+  //       expirationValid,
+  //     );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(trader);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send trader quote tokens
-      await quoteToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
-      // confirm no balance before trade.
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+  //     // send trader quote tokens
+  //     await quoteToken.transfer(trader.address, amountToAdd);
+  //     // add approvals for exchange to trade their quote tokens
+  //     await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
+  //     // confirm no balance before trade.
+  //     expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
+  //     expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
-      // swap tokens
-      const swapAmount = 100000;
-      const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
-        exchangeClass,
-        swapAmount,
-        1,
-        expirationInvalid,
-      );
+  //     // swap tokens
+  //     const swapAmount = 100000;
+  //     const testMethod = exchangeClass.swapQuoteTokenForBaseToken.bind(
+  //       exchangeClass,
+  //       swapAmount,
+  //       1,
+  //       expirationInvalid,
+  //     );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 14, Message: TIMESTAMP_EXPIRED, Path: unknown.',
-      );
-    });
+  //     await expectThrowsAsync(
+  //       testMethod,
+  //       'Origin: exchange, Code: 14, Message: TIMESTAMP_EXPIRED, Path: unknown.',
+  //     );
+  //   });
 
-    it('Should price trades correctly', async () => {
-      // create expiration 50 minutes from now.
-      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 10000;
-      const quoteTokenQtyToAdd = 50000;
+  //   it('Should price trades correctly', async () => {
+  //     // create expiration 50 minutes from now.
+  //     const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
+  //     const liquidityProvider = accounts[1];
+  //     const trader = accounts[2];
+  //     const liquidityProviderInitialBalances = 1000000;
+  //     const amountToAdd = 1000000;
+  //     const baseTokenQtyToAdd = 10000;
+  //     const quoteTokenQtyToAdd = 50000;
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(liquidityProvider);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send users (liquidity provider) base and quote tokens for easy accounting.
+  //     // send users (liquidity provider) base and quote tokens for easy accounting.
 
-      await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+  //     await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
 
-      // add approvals
+  //     // add approvals
 
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.quoteToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
-        liquidityProviderInitialBalances,
-      );
+  //     await exchangeClass.baseToken.approve(
+  //       exchangeClass.address,
+  //       liquidityProviderInitialBalances,
+  //     );
 
-      await exchangeClass.addLiquidity(
-        baseTokenQtyToAdd,
-        quoteTokenQtyToAdd,
-        1,
-        1,
-        liquidityProvider.address,
-        expiration,
-      );
+  //     await exchangeClass.addLiquidity(
+  //       baseTokenQtyToAdd,
+  //       quoteTokenQtyToAdd,
+  //       1,
+  //       1,
+  //       liquidityProvider.address,
+  //       expiration,
+  //     );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
-        sdk,
-        exchange.address,
-        baseToken.address,
-        quoteToken.address,
-      );
+  //     await sdk.changeSigner(trader);
+  //     exchangeClass = new elasticSwapSDK.Exchange(
+  //       sdk,
+  //       exchange.address,
+  //       baseToken.address,
+  //       quoteToken.address,
+  //     );
 
-      // send trader quote tokens
-      await quoteToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
-      // confirm no balance before trade.
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+  //     // send trader quote tokens
+  //     await quoteToken.transfer(trader.address, amountToAdd);
+  //     // add approvals for exchange to trade their quote tokens
+  //     await exchangeClass.quoteToken.approve(exchangeClass.address, amountToAdd);
+  //     // confirm no balance before trade.
+  //     expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(0);
+  //     expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
-      // trader executes the first trade, our pricing should be ~1:1 currently minus fees
-      const swapAmount = 100000;
-      const expectedFee = swapAmount * liquidityFee;
+  //     // trader executes the first trade, our pricing should be ~1:1 currently minus fees
+  //     const swapAmount = 100000;
+  //     const expectedFee = swapAmount * liquidityFee;
 
-      const quoteTokenReserveBalance = await quoteToken.balanceOf(exchangeClass.address);
-      const pricingConstantK =
-        (await exchangeClass.baseToken.balanceOf(exchangeClass.address)) *
-        (await exchangeClass.quoteToken.balanceOf(exchangeClass.address));
-      const baseTokenQtyReserveBeforeTrade = pricingConstantK / quoteTokenReserveBalance.toNumber();
-      const baseTokenQtyReserveAfterTrade =
-        pricingConstantK / (quoteTokenReserveBalance.toNumber() + swapAmount - expectedFee);
-      const baseTokenQtyExpected = baseTokenQtyReserveBeforeTrade - baseTokenQtyReserveAfterTrade;
+  //     const quoteTokenReserveBalance = await quoteToken.balanceOf(exchangeClass.address);
+  //     const pricingConstantK =
+  //       (await exchangeClass.baseToken.balanceOf(exchangeClass.address)) *
+  //       (await exchangeClass.quoteToken.balanceOf(exchangeClass.address));
+  //     const baseTokenQtyReserveBeforeTrade = pricingConstantK / quoteTokenReserveBalance.toNumber();
+  //     const baseTokenQtyReserveAfterTrade =
+  //       pricingConstantK / (quoteTokenReserveBalance.toNumber() + swapAmount - expectedFee);
+  //     const baseTokenQtyExpected = baseTokenQtyReserveBeforeTrade - baseTokenQtyReserveAfterTrade;
 
-      await exchangeClass.swapQuoteTokenForBaseToken(swapAmount, 1, expiration);
-      // confirm trade occurred at expected
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(
-        Math.trunc(baseTokenQtyExpected),
-      );
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(
-        amountToAdd - swapAmount,
-      );
-    });
-  });
+  //     await exchangeClass.swapQuoteTokenForBaseToken(swapAmount, 1, expiration);
+  //     // confirm trade occurred at expected
+  //     expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(
+  //       Math.trunc(baseTokenQtyExpected),
+  //     );
+  //     expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(
+  //       amountToAdd - swapAmount,
+  //     );
+  //   });
+  // });
 
   describe('addLiquidity', () => {
     it('Should quoteToken and baseToken qty to be swapped be less than quoteToken and baseToken minimum qty', async () => {

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -56,7 +56,7 @@ describe('Exchange', () => {
   });
 
   describe('getBaseTokenQtyFromQuoteTokenQty', async () => {
-    it.only('calculates expected output for current state of exchange', async () => {
+    it('calculates expected output for current state of exchange', async () => {
       const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
       // create expiration 50 minutes from now.
       const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
@@ -106,6 +106,61 @@ describe('Exchange', () => {
       );
       expect((await exchange.getBaseTokenQtyFromQuoteTokenQty(1.25)).toString()).to.be.equal(
         '6.218672655258850218',
+      );
+    });
+  });
+
+  describe('getQuoteTokenQtyFromBaseTokenQty', async () => {
+    it('calculates expected output for current state of exchange', async () => {
+      const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
+      // create expiration 50 minutes from now.
+      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
+      const liquidityProvider = accounts[1];
+      const liquidityProviderInitialBalances = 1000000;
+      const baseTokenQtyToAdd = 500000;
+      const quoteTokenQtyToAdd = 100000;
+
+      const exchangeInstance = new elasticSwapSDK.Exchange(
+        sdk,
+        exchange.address,
+        baseToken.address,
+        quoteToken.address,
+      );
+
+      // send users (liquidity provider) base and quote tokens for easy accounting.
+      await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+      await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+
+      await sdk.changeSigner(liquidityProvider);
+
+      // add approvals
+      await exchangeInstance.quoteToken.approve(
+        exchangeInstance.address,
+        liquidityProviderInitialBalances,
+      );
+
+      await exchangeInstance.baseToken.approve(
+        exchangeInstance.address,
+        liquidityProviderInitialBalances,
+      );
+
+      await exchangeInstance.addLiquidity(
+        baseTokenQtyToAdd,
+        quoteTokenQtyToAdd,
+        1,
+        1,
+        liquidityProvider.address,
+        expiration,
+      );
+
+      expect((await exchange.getQuoteTokenQtyFromBaseTokenQty(5)).toString()).to.be.equal(
+        '0.994990099848506507',
+      );
+      expect((await exchange.getQuoteTokenQtyFromBaseTokenQty(50)).toString()).to.be.equal(
+        '9.94901007349768698',
+      );
+      expect((await exchange.getQuoteTokenQtyFromBaseTokenQty(1.25)).toString()).to.be.equal(
+        '0.248749381235914175',
       );
     });
   });

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -36,7 +36,7 @@ describe('Exchange', () => {
 
   afterEach(async () => {
     const { sdk } = coreObjects;
-    // rollback to the state before the test to prevent polution
+    // rollback to the state before the test to prevent pollution
     await sdk.provider.send('evm_revert', [snapshotId]);
   });
 

--- a/test/exchange/Exchange.test.mjs
+++ b/test/exchange/Exchange.test.mjs
@@ -165,21 +165,16 @@ describe('Exchange', () => {
     });
   });
 
-  // TODO: Reenable this when the functionality is reintroduced
-  /*
-  describe.skip('swapBaseTokenForQuoteToken', () => {
-    it('Should baseToken wallet balance be less than baseToken to be swapped', async () => {
+  describe('swapBaseTokenForQuoteToken', () => {
+    it('Fails when user balance is less than swap amount', async () => {
+      const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
       // create expiration 50 minutes from now.
       const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
       const liquidityProvider = accounts[1];
-      const trader = accounts[2];
       const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 50000;
-      const quoteTokenQtyToAdd = 10000;
-
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const baseTokenQtyToAdd = 500000;
+      const quoteTokenQtyToAdd = 100000;
+      const exchangeInstance = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -187,24 +182,22 @@ describe('Exchange', () => {
       );
 
       // send users (liquidity provider) base and quote tokens for easy accounting.
-
       await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
-
       await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+      await sdk.changeSigner(liquidityProvider);
 
       // add approvals
-
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.quoteToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.baseToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.addLiquidity(
+      await exchangeInstance.addLiquidity(
         baseTokenQtyToAdd,
         quoteTokenQtyToAdd,
         1,
@@ -213,8 +206,7 @@ describe('Exchange', () => {
         expiration,
       );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const exchangeClass = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -222,15 +214,19 @@ describe('Exchange', () => {
       );
 
       // send trader base tokens
+      const trader = accounts[4];
+      const amountToAdd = 50000;
       await baseToken.transfer(trader.address, amountToAdd);
-      // add approvals for exchange to trade their quote tokens
-      await exchangeClass.baseToken.approve(exchangeClass.address, amountToAdd);
-      // confirm no balance before trade.
-      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
-      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
-      // swap tokens
+      // add approvals for exchange to trade their quote tokens
+      await sdk.changeSigner(trader);
       const swapAmount = 10000000;
+      await exchangeClass.baseToken.approve(exchangeClass.address, swapAmount);
+      // confirm no balance before trade.
+      expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
+      expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
+
+      // swap tokens
       const testMethod = exchangeClass.swapBaseTokenForQuoteToken.bind(
         exchangeClass,
         swapAmount,
@@ -238,24 +234,18 @@ describe('Exchange', () => {
         expiration,
       );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 11, Message: NOT_ENOUGH_BASE_TOKEN_BALANCE, Path: unknown.',
-      );
+      await expectThrowsAsync(testMethod, 'You don\'t have enough ETM token');
     });
 
-    it('Should baseToken allowance balance be less than baseToken to be swapped', async () => {
+    it('Fails when user approval is not sufficient', async () => {
+      const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
       // create expiration 50 minutes from now.
       const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
       const liquidityProvider = accounts[1];
-      const trader = accounts[2];
       const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 50000;
-      const quoteTokenQtyToAdd = 10000;
-
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const baseTokenQtyToAdd = 500000;
+      const quoteTokenQtyToAdd = 100000;
+      const exchangeInstance = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -263,24 +253,22 @@ describe('Exchange', () => {
       );
 
       // send users (liquidity provider) base and quote tokens for easy accounting.
-
       await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
-
       await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+      await sdk.changeSigner(liquidityProvider);
 
       // add approvals
-
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.quoteToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.baseToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.addLiquidity(
+      await exchangeInstance.addLiquidity(
         baseTokenQtyToAdd,
         quoteTokenQtyToAdd,
         1,
@@ -289,8 +277,7 @@ describe('Exchange', () => {
         expiration,
       );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const exchangeClass = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -298,15 +285,19 @@ describe('Exchange', () => {
       );
 
       // send trader base tokens
+      const trader = accounts[4];
+      const amountToAdd = 50000;
       await baseToken.transfer(trader.address, amountToAdd);
+
       // add approvals for exchange to trade their quote tokens
-      await exchangeClass.baseToken.approve(exchangeClass.address, 1);
+      await sdk.changeSigner(trader);
+      const swapAmount = 10000000;
+      // await exchangeClass.baseToken.approve(exchangeClass.address, swapAmount);
       // confirm no balance before trade.
       expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
       expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
       // swap tokens
-      const swapAmount = 100000;
       const testMethod = exchangeClass.swapBaseTokenForQuoteToken.bind(
         exchangeClass,
         swapAmount,
@@ -314,26 +305,20 @@ describe('Exchange', () => {
         expiration,
       );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 13, Message: TRANSFER_NOT_APPROVED_BY_USER, Path: unknown.',
-      );
+      await expectThrowsAsync(testMethod, 'Exchange: Not allowed to spend that much ETM token');
     });
 
-    it('Should timestamp be expired', async () => {
-      // create expiration 50 minutes from now.
-      const expirationValid = Math.round(new Date().getTime() / 1000 + 60 * 50);
+    it('Fails if timestamp is expired', async () => {
+      const { baseToken, quoteToken, elasticSwapSDK, sdk } = coreObjects;
       // create expiration 50 minutes before now.
       const expirationInvalid = Math.round(new Date().getTime() / 1000 - 60 * 50);
-      const liquidityProvider = accounts[1];
-      const trader = accounts[2];
-      const liquidityProviderInitialBalances = 1000000;
-      const amountToAdd = 1000000;
-      const baseTokenQtyToAdd = 50000;
-      const quoteTokenQtyToAdd = 10000;
+      const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
 
-      await sdk.changeSigner(liquidityProvider);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const liquidityProvider = accounts[1];
+      const liquidityProviderInitialBalances = 1000000;
+      const baseTokenQtyToAdd = 500000;
+      const quoteTokenQtyToAdd = 100000;
+      const exchangeInstance = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -341,34 +326,31 @@ describe('Exchange', () => {
       );
 
       // send users (liquidity provider) base and quote tokens for easy accounting.
-
       await baseToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
-
       await quoteToken.transfer(liquidityProvider.address, liquidityProviderInitialBalances);
+      await sdk.changeSigner(liquidityProvider);
 
       // add approvals
-
-      await exchangeClass.quoteToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.quoteToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.baseToken.approve(
-        exchangeClass.address,
+      await exchangeInstance.baseToken.approve(
+        exchangeInstance.address,
         liquidityProviderInitialBalances,
       );
 
-      await exchangeClass.addLiquidity(
+      await exchangeInstance.addLiquidity(
         baseTokenQtyToAdd,
         quoteTokenQtyToAdd,
         1,
         1,
         liquidityProvider.address,
-        expirationValid,
+        expiration,
       );
 
-      await sdk.changeSigner(trader);
-      exchangeClass = new elasticSwapSDK.Exchange(
+      const exchangeClass = new elasticSwapSDK.Exchange(
         sdk,
         exchange.address,
         baseToken.address,
@@ -376,15 +358,19 @@ describe('Exchange', () => {
       );
 
       // send trader base tokens
+      const trader = accounts[4];
+      const amountToAdd = 50000;
       await baseToken.transfer(trader.address, amountToAdd);
+
       // add approvals for exchange to trade their quote tokens
-      await exchangeClass.baseToken.approve(exchangeClass.address, amountToAdd);
+      await sdk.changeSigner(trader);
+      const swapAmount = 500;
+      await exchangeClass.baseToken.approve(exchangeClass.address, swapAmount);
       // confirm no balance before trade.
       expect((await quoteToken.balanceOf(trader.address)).toNumber()).to.equal(0);
       expect((await baseToken.balanceOf(trader.address)).toNumber()).to.equal(amountToAdd);
 
       // swap tokens
-      const swapAmount = 100000;
       const testMethod = exchangeClass.swapBaseTokenForQuoteToken.bind(
         exchangeClass,
         swapAmount,
@@ -392,13 +378,10 @@ describe('Exchange', () => {
         expirationInvalid,
       );
 
-      await expectThrowsAsync(
-        testMethod,
-        'Origin: exchange, Code: 14, Message: TIMESTAMP_EXPIRED, Path: unknown.',
-      );
+      await expectThrowsAsync(testMethod, 'Exchange: Requested expiration is in the past');
     });
 
-    it('Should price trades correctly', async () => {
+    it.only('Should price trades correctly', async () => {
       // create expiration 50 minutes from now.
       const expiration = Math.round(new Date().getTime() / 1000 + 60 * 50);
       const liquidityProvider = accounts[1];
@@ -800,7 +783,6 @@ describe('Exchange', () => {
       );
     });
   });
-  */
 
   describe('addLiquidity', () => {
     it('Should quoteToken and baseToken qty to be swapped be less than quoteToken and baseToken minimum qty', async () => {

--- a/test/utils/mathLib2.test.mjs
+++ b/test/utils/mathLib2.test.mjs
@@ -1,0 +1,106 @@
+/* eslint import/extensions: 0 */
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import {
+  BASIS_POINTS,
+  calculateQtyToReturnAfterFees,
+  getBaseQtyFromQuoteQty,
+} from '../../src/utils/mathLib2.mjs';
+
+describe('MathLib2', async () => {
+  describe('calculateQtyToReturnAfterFees', () => {
+    it('works with 2 - 18 decimal tokens', () => {
+      const tokenASwapQty = ethers.utils.parseUnits('100', 18);
+      const tokenAReserveQty = ethers.utils.parseUnits('150000000', 18);
+      const tokenBReserveQty = ethers.utils.parseUnits('75000000', 18);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const output = calculateQtyToReturnAfterFees(
+        tokenASwapQty,
+        tokenAReserveQty,
+        tokenBReserveQty,
+        fee,
+      );
+      expect(output.toString()).to.equal('49749966999188557204');
+    });
+
+    it('works with a 18 decimal token and a 6 decimal token', () => {
+      const tokenASwapQty = ethers.utils.parseUnits('100', 18);
+      const tokenAReserveQty = ethers.utils.parseUnits('150000000', 18);
+      const tokenBReserveQty = ethers.utils.parseUnits('75000000', 6);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const output = calculateQtyToReturnAfterFees(
+        tokenASwapQty,
+        tokenAReserveQty,
+        tokenBReserveQty,
+        fee,
+      );
+      expect(output.toString()).to.equal('49749966');
+    });
+
+    it('works with a 9 decimal token and a 6 decimal token', () => {
+      const tokenASwapQty = ethers.utils.parseUnits('100', 9);
+      const tokenAReserveQty = ethers.utils.parseUnits('150000000', 9);
+      const tokenBReserveQty = ethers.utils.parseUnits('75000000', 6);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const output = calculateQtyToReturnAfterFees(
+        tokenASwapQty,
+        tokenAReserveQty,
+        tokenBReserveQty,
+        fee,
+      );
+      expect(output.toString()).to.equal('49749966');
+    });
+
+    it('Properly extracts fee amounts', () => {
+      const tokenASwapQty = ethers.utils.parseUnits('100', 18);
+      const tokenAReserveQty = ethers.utils.parseUnits('150000000', 18);
+      const tokenBReserveQty = ethers.utils.parseUnits('75000000', 18);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const outputWithFee = calculateQtyToReturnAfterFees(
+        tokenASwapQty,
+        tokenAReserveQty,
+        tokenBReserveQty,
+        fee,
+      );
+      expect(outputWithFee.toString()).to.equal('49749966999188557204');
+
+      const outputWithOutFee = calculateQtyToReturnAfterFees(
+        tokenASwapQty,
+        tokenAReserveQty,
+        tokenBReserveQty,
+        ethers.BigNumber.from(0),
+      );
+
+      const diff = outputWithOutFee.sub(outputWithFee);
+      const diffInBP = diff.mul(BASIS_POINTS).div(outputWithOutFee);
+      expect(diffInBP.toString()).to.equal('49');
+    });
+  });
+
+  describe('getBaseQtyFromQuoteQty', () => {
+    it('works with 2 - 18 decimal tokens without decay', () => {
+      const quoteTokenQtyToSwap = ethers.utils.parseUnits('100', 18);
+      const quoteTokenReserveQty = ethers.utils.parseUnits('150000000', 18);
+      const baseTokenReserveQty = ethers.utils.parseUnits('75000000', 18);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const output = getBaseQtyFromQuoteQty(quoteTokenQtyToSwap, baseTokenReserveQty, fee, {
+        quoteTokenReserveQty,
+        baseTokenReserveQty,
+      });
+      expect(output.toString()).to.equal('49749966999188557204');
+    });
+
+    it('works with 2 - 18 decimal tokens with decay', () => {
+      const quoteTokenQtyToSwap = ethers.utils.parseUnits('100', 18);
+      const quoteTokenReserveQty = ethers.utils.parseUnits('150000000', 18);
+      const baseTokenReserveQty = ethers.utils.parseUnits('75000000', 18);
+      const decayAmount = ethers.utils.parseUnits('50000', 18);
+      const fee = ethers.BigNumber.from(50); // basis points;
+      const output = getBaseQtyFromQuoteQty(quoteTokenQtyToSwap, baseTokenReserveQty, fee, {
+        quoteTokenReserveQty,
+        baseTokenReserveQty: baseTokenReserveQty.add(decayAmount),
+      });
+      expect(output.toString()).to.equal('49783133621839489500');
+    });
+  });
+});

--- a/test/utils/mathLib2.test.mjs
+++ b/test/utils/mathLib2.test.mjs
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import {
   BASIS_POINTS,
   calculateQtyToReturnAfterFees,
-  getBaseQtyFromQuoteQty,
+  getBaseTokenQtyFromQuoteTokenQty,
 } from '../../src/utils/mathLib2.mjs';
 
 describe('MathLib2', async () => {
@@ -77,16 +77,21 @@ describe('MathLib2', async () => {
     });
   });
 
-  describe('getBaseQtyFromQuoteQty', () => {
+  describe('getBaseTokenQtyFromQuoteTokenQty', () => {
     it('works with 2 - 18 decimal tokens without decay', () => {
       const quoteTokenQtyToSwap = ethers.utils.parseUnits('100', 18);
       const quoteTokenReserveQty = ethers.utils.parseUnits('150000000', 18);
       const baseTokenReserveQty = ethers.utils.parseUnits('75000000', 18);
       const fee = ethers.BigNumber.from(50); // basis points;
-      const output = getBaseQtyFromQuoteQty(quoteTokenQtyToSwap, baseTokenReserveQty, fee, {
-        quoteTokenReserveQty,
+      const output = getBaseTokenQtyFromQuoteTokenQty(
+        quoteTokenQtyToSwap,
         baseTokenReserveQty,
-      });
+        fee,
+        {
+          quoteTokenReserveQty,
+          baseTokenReserveQty,
+        },
+      );
       expect(output.toString()).to.equal('49749966999188557204');
     });
 
@@ -96,10 +101,15 @@ describe('MathLib2', async () => {
       const baseTokenReserveQty = ethers.utils.parseUnits('75000000', 18);
       const decayAmount = ethers.utils.parseUnits('50000', 18);
       const fee = ethers.BigNumber.from(50); // basis points;
-      const output = getBaseQtyFromQuoteQty(quoteTokenQtyToSwap, baseTokenReserveQty, fee, {
-        quoteTokenReserveQty,
-        baseTokenReserveQty: baseTokenReserveQty.add(decayAmount),
-      });
+      const output = getBaseTokenQtyFromQuoteTokenQty(
+        quoteTokenQtyToSwap,
+        baseTokenReserveQty,
+        fee,
+        {
+          quoteTokenReserveQty,
+          baseTokenReserveQty: baseTokenReserveQty.add(decayAmount),
+        },
+      );
       expect(output.toString()).to.equal('49783133621839489500');
     });
   });


### PR DESCRIPTION
 - adds clean ethers BN math implementation and easy to access function one exchange
 - updates swap functions
 
Question:

- Should we implement a `swapBaseToken(input, slippage, timeout)` function, one concern is that their is a tiny possibility that the user sees a min output amount that is different than we calculate it as in the SDK, but it does simplify things.
- we need to fix the tests.  It looks like something with the cacheing is making us not have a clean state in between tests.  Individually tests pass, but collectively they fail due to pollution.  `{ multicall: true }` as an override seems to fix this by forcing a call. 
 
