### PR TITLE
Feature/calculate usdc value from claim

### DIFF
--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 export const BASIS_POINTS = ethers.BigNumber.from('10000');
 const ZERO = ethers.BigNumber.from(0);
 const ONE = ethers.BigNumber.from(1);
-const TWO = ethers.BigNumber.from(2);
+export const TWO = ethers.BigNumber.from(2);
 export const WAD = ethers.utils.parseUnits('1', 18);
 
 export const getAddLiquidityBaseTokenQtyFromQuoteTokenQty = (
@@ -529,6 +529,25 @@ export const calculateMaxQuoteTokenQtyWhenBaseDecayIsPresentForSingleAssetEntry 
   // alphaDecay / omega (A/B)
   const maxQuoteTokenQty = wDiv(baseTokenDecay, internalBaseTokenToQuoteTokenRatio);
   return maxQuoteTokenQty;
+};
+
+/**
+ * Calculates the USDC value of the "totalLPTokenAmount" LP tokens from the merkle tree
+ * @param {ethers.BigNumber} totalLPTokenAmountToBeClaimed 
+ * @param {ethers.BigNumber} totalSupplyOfLiquidityTokens The total Supply of LP tokens in the TIC/USDC pool
+ * @param {ethers.BigNumber} quoteTokenQty The total amount of USDC in the TIC/USDC pool
+ * @returns lpTokenQty to be minted to the fee address on the next liquidity event.
+ */
+export const calculateUSDCValueOfLPClaim = (
+  totalLPTokenAmountToBeClaimed,
+  totalSupplyOfLiquidityTokens,
+  quoteTokenQty,
+) => {
+  const usdvValueOfLPClaim = totalLPTokenAmountToBeClaimed
+    .div(totalSupplyOfLiquidityTokens)
+    .mul(quoteTokenQty)
+    .mul(TWO);
+  return usdvValueOfLPClaim;
 };
 
 /**

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -533,6 +533,8 @@ export const calculateMaxQuoteTokenQtyWhenBaseDecayIsPresentForSingleAssetEntry 
 
 /**
  * Calculates the USDC value of the "totalLPTokenAmount" LP tokens from the merkle tree
+ * USDCValue = (totalLPTokenAmountToBeClaimed / totalSupplyOfLiquidityTokens)
+ *             * quoteTokenQty * 2
  * @param {ethers.BigNumber} totalLPTokenAmountToBeClaimed
  * @param {ethers.BigNumber} totalSupplyOfLiquidityTokens total Supply of LP tokens in TIC/USDC pool
  * @param {ethers.BigNumber} quoteTokenQty The total amount of USDC in the TIC/USDC pool

--- a/src/utils/mathLib.mjs
+++ b/src/utils/mathLib.mjs
@@ -533,8 +533,8 @@ export const calculateMaxQuoteTokenQtyWhenBaseDecayIsPresentForSingleAssetEntry 
 
 /**
  * Calculates the USDC value of the "totalLPTokenAmount" LP tokens from the merkle tree
- * @param {ethers.BigNumber} totalLPTokenAmountToBeClaimed 
- * @param {ethers.BigNumber} totalSupplyOfLiquidityTokens The total Supply of LP tokens in the TIC/USDC pool
+ * @param {ethers.BigNumber} totalLPTokenAmountToBeClaimed
+ * @param {ethers.BigNumber} totalSupplyOfLiquidityTokens total Supply of LP tokens in TIC/USDC pool
  * @param {ethers.BigNumber} quoteTokenQty The total amount of USDC in the TIC/USDC pool
  * @returns lpTokenQty to be minted to the fee address on the next liquidity event.
  */

--- a/test/utils/mathLib.test.mjs
+++ b/test/utils/mathLib.test.mjs
@@ -510,7 +510,7 @@ describe('MathLib', async () => {
   });
 
   describe('calculateUSDCValueOfLPClaim', () => {
-    it.only('calculates the USDC value of claimmable LP correctly', () => {
+    it('calculates the USDC value of claimmable LP correctly', () => {
       const totalLPTokenAmountToBeClaimed = ethers.BigNumber.from('10');
       const totalSupplyOfLiquidityTokens = ethers.BigNumber.from('1000');
       const usdcTokenQty = ethers.BigNumber.from('10000');

--- a/test/utils/mathLib.test.mjs
+++ b/test/utils/mathLib.test.mjs
@@ -4,11 +4,13 @@ import { ethers } from 'ethers';
 import {
   BASIS_POINTS,
   calculateQtyToReturnAfterFees,
+  calculateUSDCValueOfLPClaim,
   getAddLiquidityBaseTokenQtyFromQuoteTokenQty,
   getAddLiquidityQuoteTokenQtyFromBaseTokenQty,
   getBaseTokenQtyFromQuoteTokenQty,
   getLPTokenQtyFromTokenQtys,
   getTokenImbalanceQtys,
+  TWO,
   WAD,
 } from '../../src/utils/mathLib.mjs';
 
@@ -504,6 +506,24 @@ describe('MathLib', async () => {
 
       expect(tokenImbalanceQtys.quoteTokenImbalanceQty.eq(ethers.constants.Zero)).to.be.true;
       expect(tokenImbalanceQtys.baseTokenImbalanceQty.eq(decay)).to.be.true;
+    });
+  });
+
+  describe('calculateUSDCValueOfLPClaim', () => {
+    it.only('calculates the USDC value of claimmable LP correctly', () => {
+      const totalLPTokenAmountToBeClaimed = ethers.BigNumber.from('10');
+      const totalSupplyOfLiquidityTokens = ethers.BigNumber.from('1000');
+      const usdcTokenQty = ethers.BigNumber.from('10000');
+      const usdcValueOfLPClaimExpected = totalLPTokenAmountToBeClaimed
+        .div(totalSupplyOfLiquidityTokens)
+        .mul(usdcTokenQty)
+        .mul(TWO);
+      const usdcValueOfLPClaimCalculated = calculateUSDCValueOfLPClaim(
+        totalLPTokenAmountToBeClaimed,
+        totalSupplyOfLiquidityTokens,
+        usdcTokenQty,
+      );
+      expect(usdcValueOfLPClaimExpected.eq(usdcValueOfLPClaimCalculated)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Adds a function in the math lib to be able to take in `totalLPTokenAmountToBeClaimed` and return its USDC value at that moment.

This function could be later used in a tooling/analytics dashboard to show a user's position etc.

Note:
* All tests pass
